### PR TITLE
jupyter uses python2 instead of python3 for consistency with FlashX a…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,10 +53,10 @@ RUN ./install_FlashGraphR.sh
 
 ####R finished####
 
-RUN apt-get install -y python3-pip
+RUN apt-get install -y python-pip
 RUN apt-get install -y libcurl4-openssl-dev libssl-dev
-RUN pip3 install --upgrade pip
-RUN pip3 install jupyter
+RUN pip install --upgrade pip
+RUN pip install jupyter
 RUN R -e "install.packages(c('repr', 'IRdisplay', 'evaluate', 'crayon', 'pbdZMQ', 'devtools', 'uuid', 'digest'), repos = 'http://cran.rstudio.com/')"
 RUN R -e "devtools::install_github('IRkernel/IRkernel')"
 RUN R -e "IRkernel::installspec()"


### PR DESCRIPTION
as the PR states; double check with an example or two first to make sure it is still in good order though!